### PR TITLE
Add phpstan.src.neon to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@
 /.gitattributes    export-ignore
 /.github           export-ignore
 /.gitignore        export-ignore
+/phpstan.src.neon  export-ignore
 /.php_cs           export-ignore
 /README.md         export-ignore
 /CHANGELOG.md      export-ignore


### PR DESCRIPTION
Removes phpstan.src.neon from composer installs et al