### PR TITLE
Adding FileinfoSupportMissing Exception

### DIFF
--- a/src/Exceptions/FileinfoSupportMissing.php
+++ b/src/Exceptions/FileinfoSupportMissing.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * League.Uri (https://uri.thephpleague.com)
+ *
+ * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace League\Uri\Exceptions;
+
+use League\Uri\Contracts\UriException;
+
+class FileinfoSupportMissing extends \RuntimeException implements UriException
+{
+}


### PR DESCRIPTION
Following the PR [#154](https://github.com/thephpleague/uri/pull/154) addition.

We are moving the exception to the interfaces package to enable using the same exception in all implementing packages.