### PR TITLE
Allow PHP 8 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php" : "^7.1",
+        "php" : "^7.1|^8.0",
         "ext-json": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Allow installing this package on PHP 8.

Closes thephpleague/uri-src#102 

It is still impossible to do a regular `composer install` in the "dev-mode" though.
There are two blocking dependencies: `friendsofphp/php-cs-fixer` is in process of adopting the PHP 8 support, and `phpunit/phpunit`'s version is limited to 8.0 in this package, raising it to 9.0 would solve the issue. The PHPUnit though is not used at all, so it might be plausible to just remove it from require-dev.