### PR TITLE
Remove property type to regain PHP 7.2 compatibility

### DIFF
--- a/src/IdnaInfo.php
+++ b/src/IdnaInfo.php
@@ -52,7 +52,7 @@ final class IdnaInfo
     /**
      * @var array<int, string>
      */
-    private array $errorList;
+    private $errorList;
 
     private function __construct(string $result, bool $isTransitionalDifferent, int $errors)
     {


### PR DESCRIPTION
This issue has popped up in Symfony's CI:

https://travis-ci.com/github/symfony/symfony/jobs/505713677#L10197

Property types have been introduced with PHP 7.4. Removing the property type should make the codebase compatible with PHP 7.2 and 7.3 again.